### PR TITLE
Fix: Forward propagation skips layers

### DIFF
--- a/vijax/vardists/Flows.py
+++ b/vijax/vardists/Flows.py
@@ -804,7 +804,7 @@ class RealNVP(Flows):
         inputs = leakyrelu(jnp.dot(inputs, inpW) + inpb)
 
         for W, b in params[1:-1]:
-            outputs = jnp.dot(inputs, W) + b
+            inputs = leakyrelu(jnp.dot(inputs, W) + b)
 
         outW, outb = params[-1]
         outputs = jnp.dot(inputs, outW) + outb


### PR DESCRIPTION
Forward propagation in coupling layers no longer skips neural network layers.

Coupling layer neural network was incorrectly applied. We now (1) apply non-linearity at every hidden layer and (2) carry the output forward such that we do not skip hidden layers.

Please look at the code to better understand this fix. Also, I have not tested this code so please confirm it does not negatively affect the optimization procedure.